### PR TITLE
Add instructions for user queueing and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The `cc` utility is in the `bin` directory of this repo. It can be run interactively or as a single command processor. The general format of using the command line is
 
 ```
-node cc [options] [command]
+node bin/cc [options] [command]
 ```
 
 where the available options are:
@@ -26,7 +26,7 @@ The available commands are:
 
  `queue <requests...>` -- Queues the given requests for processing. The requests parameter is a list of GitHub "${org}" and/or "${org}/${repo}" and/or "users/${user}" names.
 
-`orgs <org orgs...>` -- Set the crawler's to traverse only the GitHub orgs named in the given list.
+`orgs <org orgs...>` -- Set the crawlers to traverse only the GitHub orgs named in the given list.
 
 `config` -- Dumps the crawler service's configuration to the console.
 
@@ -35,7 +35,7 @@ The available commands are:
 A typical sequence shown in the snippet below configures the crawler with a set of tokens, configures the org filter set and then queues and starts the processing of the org.
 
 ```
-> node bin/cc
+> node bin/cc -i
 http://localhost:3000> tokens 43984b2344ca575d0f0e097efd97#public 972bbdfe098098fa9ce082309#admin
 http://localhost:3000> orgs contoso-d
 http://localhost:3000> queue contoso-d

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The available commands are:
 
  `stop` -- Stop crawler processing. The crawler service is left running but it stops pulling requests off the queue.  This is the same as `start 0`.
 
- `queue <requests...>` -- Queues the given requests for processing. The requests parameter is a list of GitHub "org" and/or "org/repo" names.
+ `queue <requests...>` -- Queues the given requests for processing. The requests parameter is a list of GitHub "${org}" and/or "${org}/${repo}" and/or "users/${user}" names.
 
 `orgs <org orgs...>` -- Set the crawler's to traverse only the GitHub orgs named in the given list.
 
@@ -39,6 +39,16 @@ A typical sequence shown in the snippet below configures the crawler with a set 
 http://localhost:3000> tokens 43984b2344ca575d0f0e097efd97#public 972bbdfe098098fa9ce082309#admin
 http://localhost:3000> orgs contoso-d
 http://localhost:3000> queue contoso-d
+http://localhost:3000> start 5
+http://localhost:3000> exit
+```
+
+Here's another example. If you want to queue up 2 users, without configuring an org, you can use this sequence. This is useful if you want to capture all events from a specific user or users.
+
+```
+> node bin/cc -i
+http://localhost:3000> tokens 43984b2344ca575d0f0e097efd97#public 972bbdfe098098fa9ce082309#admin
+http://localhost:3000> queue users/octocat users/microsoftopensource
 http://localhost:3000> start 5
 http://localhost:3000> exit
 ```

--- a/bin/cc
+++ b/bin/cc
@@ -43,7 +43,7 @@ function getCommands() {
   commands
     .command('queue <requests...>')
     .option('-q, --queue <name>', 'The queue onto which the requests are pushed')
-    .description('Queue the given list of orgs and/or repos to be processed.')
+    .description('Queue the given list of orgs and/or repos and/or users to be processed.')
     .action((requests, options) => queueRequests(requests, options));
   commands
     .command('start [count]')


### PR DESCRIPTION
This PR is a companion to a PR in the crawler. https://github.com/microsoft/ghcrawler/pull/175
This commit explains how to use the new crawler functionality when queuing through the cli. 
So, probably don't merge this commit until the other is merged.
(The second commit in this PR makes a few changes to the README for clarity for new users, unrelated to user queueing specifically) 
